### PR TITLE
supporting CSStyleDeclaration style

### DIFF
--- a/cell.js
+++ b/cell.js
@@ -222,6 +222,9 @@
         // "_" variables don't directly alter the phenotype, so do nothing
       } else if (key === 'value') {
         $node[key] = val;
+      } else if (key === 'style' && typeof val === 'object') {
+        var CSSStyleDeclaration = Object.getOwnPropertyDescriptor($root.HTMLElement.prototype, key).get.call($node);
+        for (var attr in val) { CSSStyleDeclaration[attr] = val[attr]; }
       } else if (typeof val === 'number' || typeof val === 'string' || typeof val === 'boolean') {
         if ($node.setAttribute) $node.setAttribute(key, val);
       } else if (typeof val === 'function') {
@@ -345,6 +348,8 @@
             if (key === 'value') {
               // The "value" attribute needs a special treatment.
               return Object.getOwnPropertyDescriptor(Object.getPrototypeOf($node), key).get.call($node);
+            } else if (key === 'style') {
+              return Object.getOwnPropertyDescriptor($root.HTMLElement.prototype, key).get.call($node);
             } else if (key in $node.Genotype) {
               // Otherwise utilize Genotype
               return $node.Genotype[key];
@@ -376,6 +381,8 @@
           if (key[0] !== '$' && key[0] !== '_') {
             if (key === 'value') {
               return Object.getOwnPropertyDescriptor(Object.getPrototypeOf($node), key).set.call($node, val);
+            } else if (key === 'style' && typeof val === 'object') {
+              Object.getOwnPropertyDescriptor($root.HTMLElement.prototype, key).set.call($node, val);
             } else if (typeof val === 'number' || typeof val === 'string' || typeof val === 'boolean') {
               $node.setAttribute(key, val);
             } else if (typeof val === 'function') {

--- a/test/Phenotype.js
+++ b/test/Phenotype.js
@@ -391,7 +391,64 @@ describe("Phenotype", function() {
     describe("[_] User defined variables", function() {
     })
     describe("[ ] dom attributes", function() {
+      describe("object", function() {
+        it("style", function() {
+          const $parent = document.createElement("div");
+          const $node = document.createElement("div")
+          $node.Genotype = {}
+          $node.Meta = {}
+          $parent.appendChild($node)
+
+          // normally it's set directly on the DOM as an attribute
+          var styleAttr = $node.getAttribute("style");
+          compare(styleAttr, null);
+
+          var styleProp = $node.style;
+          compare(Object.getPrototypeOf(styleProp).constructor.name, "CSSStyleDeclaration");
+
+          Phenotype.set($node, "style", {
+            backgroundColor: "red",
+            fontFamily: "Courier"
+          })
+
+          styleAttr = $node.getAttribute("style");
+          styleProp = $node.style;
+         
+          compare(styleAttr, "background-color: red; font-family: Courier;")
+          compare(styleProp.backgroundColor, "red");
+          compare(styleProp.fontFamily, "Courier");
+
+          compare(Object.getPrototypeOf(styleProp).constructor.name, "CSSStyleDeclaration");
+          
+        });
+      });
       describe("string", function() {
+        it("style", function() {
+          const $parent = document.createElement("div");
+          const $node = document.createElement("div")
+          $node.Genotype = {}
+          $node.Meta = {}
+          $parent.appendChild($node)
+
+          // normally it's set directly on the DOM as an attribute
+          var styleAttr = $node.getAttribute("style");
+          compare(styleAttr, null);
+
+          var styleProp = $node.style;
+          compare(Object.getPrototypeOf(styleProp).constructor.name, "CSSStyleDeclaration");
+
+          Phenotype.set($node, "style", "background-color: red;")
+
+          styleAttr = $node.getAttribute("style");
+          styleProp = $node.style;
+         
+          compare(styleAttr, "background-color: red;")
+          // even if we initially set the style as string,
+          // we should be able to access it as an object property
+          compare(styleProp.backgroundColor, "red");
+          compare(Object.getPrototypeOf(styleProp).constructor.name, "CSSStyleDeclaration");
+          
+        });
         it("class", function() {
           const $parent = document.createElement("div");
           const $node = document.createElement("div")

--- a/test/spy.js
+++ b/test/spy.js
@@ -6,7 +6,8 @@ module.exports = {
     update: sinon.spy(Genotype, "update")
   },
   O: {
-    defineProperty: sinon.spy(Object, "defineProperty")
+    defineProperty: sinon.spy(Object, "defineProperty"),
+    getOwnPropertyDescriptor: sinon.spy(Object, "getOwnPropertyDescriptor")
   },
   Gene: {
     freeze: sinon.spy(Gene, "freeze")


### PR DESCRIPTION
This PR adds support for [CSSStyleDeclaration](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleDeclaration) type style.

# Problem

Previously the `style` attribute was directly being set as string, which is the intended behavior if `style` was an ordinary attribute. But it's not. Internally it has its own data structure CSSStyleDeclaration. More discussion on this here https://github.com/intercellular/cell/issues/136

# Solution

The solution:

1. supports an object notation (in addition to the string format) for setting the style.
2. overrides the getter so that even if the attribute was set as a string it can be retrieved as `CSSStyleDeclaration` object.

Example:

```
d = {
  $cell: true,
  $type: 'div',
  $text: 'Send message',
  style: {
    fontFamily: "Courier",
    color: "white",
    padding: "20px",
    backgroundColor: "red"
  }
}
```

This is same as using the string format:

```
d = {
  $cell: true,
  $type: 'div',
  $text: 'Send message',
  style: "background-color: yellow; color: white; padding: 20px; font-family: Courier;"
}
```

Also it can be modified: 

```
d = {
  $cell: true,
  $type: 'div',
  $text: 'Send message',
  style: "background-color: yellow; color: white; padding: 20px; font-family: Courier;",
  onmouseover: function() {
    this.style.backgroundColor = "blue"; // It works!
    this.style.fontFamily = "Arial";
  },
  onmouseout: function() {
    this.style.backgroundColor = "red"; // It works!
    this.style.fontFamily = "Courier";
  }
}
```

You can play with the fiddle here: https://jsfiddle.net/1y8xfL7j/