### PR TITLE
Initialize parent before children

### DIFF
--- a/cell.js
+++ b/cell.js
@@ -191,12 +191,12 @@
      *   - $update(): executes the "$update" callback function when needed (called by Nucleus on every tick)
      */
     build: function($node, genotype) {
+      Phenotype.$init($node);
       for (var key in genotype) {
         if (genotype[key] !== null && genotype[key] !== undefined) {
           Phenotype.set($node, key, genotype[key]);
         }
       }
-      Phenotype.$init($node);
     },
     multiline: function(fn) { return /\/\*!?(?:@preserve)?[ \t]*(?:\r\n|\n)([\s\S]*?)(?:\r\n|\n)[ \t]*\*\//.exec(fn.toString())[1]; },
     get: function(key) {


### PR DESCRIPTION
Initialize parent node before children. 

This should fix the problem mentioned here https://github.com/intercellular/cell/issues/155

Previously `$init` was being called from the bottom up. So if the tree structure looked like:

```
A
  - B
  - C
    - D
```

The `$init()` execution order was:

1. B.$init()
2. D.$init()
3. C.$init()
4. A.$init()

because it was depth first search based. (See demo: https://jsfiddle.net/bnLw8htg/1/)

With this update now the order will be

1. A.$init()
2. B.$init()
3. C.$init()
4. D.$init()

(See demo: https://jsfiddle.net/bnLw8htg/2/)