### PR TITLE
Clean Nucleus queue when removing an element

### DIFF
--- a/cell.js
+++ b/cell.js
@@ -286,6 +286,9 @@
           return $node.Kill;
         }).forEach(function($node) {
           $parent.removeChild($node);
+          setTimeout(function(){
+            Nucleus.disconnect($node);
+          }, 0);
         });
         diff['+'].forEach(function(item) {
           var inheritance = $parent.Inheritance;
@@ -513,6 +516,11 @@
         $node.Dirty[key] = Gene.freeze($node.Genotype[key]); // stores the original value under "Dirty"
       }
     },
+    disconnect: function($node) {
+      var index = Nucleus._queue.indexOf($node);
+      if (index !== -1) Nucleus._queue.splice(index, 1);
+      $node.childNodes.forEach(Nucleus.disconnect);
+    }
   };
   var God = {
     /*

--- a/cell.js
+++ b/cell.js
@@ -286,7 +286,7 @@
           return $node.Kill;
         }).forEach(function($node) {
           $parent.removeChild($node);
-          setTimeout(function(){
+          setTimeout(function() {
             Nucleus.disconnect($node);
           }, 0);
         });
@@ -520,7 +520,7 @@
       var index = Nucleus._queue.indexOf($node);
       if (index !== -1) Nucleus._queue.splice(index, 1);
       $node.childNodes.forEach(Nucleus.disconnect);
-    }
+    },
   };
   var God = {
     /*


### PR DESCRIPTION
This was generating big memory leaks when creating and replacing
several components permanently.